### PR TITLE
100vh automatical correction (for some mobile devices)

### DIFF
--- a/gulp-tasks/styles.js
+++ b/gulp-tasks/styles.js
@@ -18,7 +18,6 @@ import { PRODUCTION } from '../config';
 const fixVieportHeight = postcss.plugin('postcss-fix-vh', function() {
 	return function(root) {
 		root.walkRules(function(rule) {
-			let ruleSelectors = rule.selector.split(',').map(str => str.trim());
 			rule.walkDecls(function(decl) {
 				let value = decl.value;
 				let hasVhUnits = /vh/.test(value) && !/calc\(.*vh.*\)/.test(value);
@@ -27,9 +26,8 @@ const fixVieportHeight = postcss.plugin('postcss-fix-vh', function() {
 				}
 
 				let newValue = value.replace(/([0-9\.\-]+)vh/g, 'calc($1vh - $1 / 100 * var(--fix100vhValue))');
-				let newRuleString =
-					ruleSelectors.map(selector => `._fix100vh ${selector}`).join(', ') + ` { ${decl.prop}: ${newValue} }`;
-				rule.parent.insertAfter(rule, '\n' + newRuleString);
+				let newRuleString = `${decl.prop}: ${newValue}`;
+				decl.after(newRuleString);
 			});
 		});
 	};

--- a/src/media/sass/_reset.sass
+++ b/src/media/sass/_reset.sass
@@ -3,6 +3,9 @@
 	margin: 0
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0)
 
+html
+	--fix100vhValue: 0px
+
 html, body
 	width: 100%
 	height: 100%
@@ -70,7 +73,7 @@ input[type=search]
 	background: #5f5f5f
 	color: #FFFFFF
 	text-shadow: none
-	
+
 ::-moz-selection
 	background: #5f5f5f
 	color: #FFFFFF

--- a/src/templates/parts/_head-scripts.nunj
+++ b/src/templates/parts/_head-scripts.nunj
@@ -62,26 +62,61 @@
 			var xhr = new XMLHttpRequest();
 			xhr.open('GET', 'media/svg/sprite.svg', true);
 			xhr.overrideMimeType('image/svg+xml');
-			
-			xhr.onreadystatechange = function(){
-				if(xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+
+			xhr.onreadystatechange = function() {
+				if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
 					var container = document.createElement('div');
 					container.className = 'invisible-container';
 					container.appendChild(xhr.responseXML.documentElement);
 
-					function waitForBody(){
-						if(document.body){
+					function waitForBody() {
+						if (document.body) {
 							document.body.appendChild(container);
 						} else {
 							setTimeout(waitForBody, 16)
 						}
 					}
 
-					waitForBody();	
+					waitForBody();
 				};
 			}
 
 			xhr.send('');
+
+			// Fix 100vh bug on iPhoneX
+			// and other mobile devices
+			if (localStorage && localStorage.getItem('fix100vhValue')) {
+				document.documentElement.classList.add('_fix100vh');
+				typeof document.documentElement.style.setProperty === 'function' && document.documentElement.style.setProperty('--fix100vhValue', localStorage.getItem('fix100vhValue') + 'px');
+			} else {
+				var waitForBody = function() {
+					if (document.body) {
+						var tolerance = 10;
+						var check100vhElem = document.createElement('div');
+						var check100vhElemStyle = check100vhElem.style;
+						check100vhElemStyle.visibility = 'hidden';
+						check100vhElemStyle.position = 'absolute';
+						check100vhElemStyle.left = '0';
+						check100vhElemStyle.top = '0';
+						check100vhElemStyle.width = '1px';
+						check100vhElemStyle.height = '100vh';
+						document.body.appendChild(check100vhElem);
+						var real100vhHeight = check100vhElem.clientHeight;
+						check100vhElem.parentNode.removeChild(check100vhElem);
+						var delta = real100vhHeight - window.innerHeight;
+						if (Math.abs(delta) > tolerance) {
+							document.documentElement.classList.add('_fix100vh');
+							typeof document.documentElement.style.setProperty === 'function' && document.documentElement.style.setProperty('--fix100vhValue', delta + 'px');
+							if (localStorage) {
+								localStorage.setItem('fix100vhValue', delta);
+							}
+						}
+					} else {
+						setTimeout(waitForBody, 16)
+					}
+				}
+				waitForBody();
+			}
 		})();
 	</script>
 {% endmacro %}

--- a/src/templates/parts/_head-scripts.nunj
+++ b/src/templates/parts/_head-scripts.nunj
@@ -86,7 +86,6 @@
 			// Fix 100vh bug on iPhoneX
 			// and other mobile devices
 			if (localStorage && localStorage.getItem('fix100vhValue')) {
-				document.documentElement.classList.add('_fix100vh');
 				typeof document.documentElement.style.setProperty === 'function' && document.documentElement.style.setProperty('--fix100vhValue', localStorage.getItem('fix100vhValue') + 'px');
 			} else {
 				var waitForBody = function() {
@@ -105,7 +104,6 @@
 						check100vhElem.parentNode.removeChild(check100vhElem);
 						var delta = real100vhHeight - window.innerHeight;
 						if (Math.abs(delta) > tolerance) {
-							document.documentElement.classList.add('_fix100vh');
 							typeof document.documentElement.style.setProperty === 'function' && document.documentElement.style.setProperty('--fix100vhValue', delta + 'px');
 							if (localStorage) {
 								localStorage.setItem('fix100vhValue', delta);


### PR DESCRIPTION
На некоторых мобилках (например, на iPhoneX, а также ряде других), блок с высотой 100vh будет вылезать за пределы видимой области экрана, потому что есть полоса интерфейса браузеа (адресная строка, или кнопки навигации, или ещё что). Эта полоса идёт поверх контента, но почему-то производители не спешат это править. Для них это фича, а не баг.

В этом PR реализован механизм, который приводит vh-единицы к единому виду, для разных мобилок. Можно писать 100vh и быть увереным, что это будет видимая область экрана. Можно писать 50vh и быть уверенным, что это середина экрана. И так далее. Скрипт автоматически определит, нужна ли корректировка, проставит класс _fix100vh на html, и в стилях пропишет нужные формулки. Работает через calc() и CSS-переменные.