### PR TITLE
Build warnings removed

### DIFF
--- a/gulp-tasks/styles.js
+++ b/gulp-tasks/styles.js
@@ -17,7 +17,6 @@ import { PRODUCTION } from '../config';
 
 const PROCESSORS = [
 	autoprefixer({
-		browsers: ['last 4 versions'],
 		cascade: true,
 	}),
 	assets({
@@ -29,7 +28,8 @@ const PROCESSORS = [
 		spritePath: './build/media/img/',
 		retina: true,
 		padding: 4,
-		filterBy: image => (/sprites\/.*\.png$/gi.test(image.url) ? Promise.resolve() : Promise.reject()),
+		filterBy: image =>
+			/sprites\/.*\.png$/gi.test(image.url) ? Promise.resolve() : Promise.reject(),
 	}),
 ];
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
 		"zip": "cross-env NODE_ENV=production gulp zip",
 		"precommit": "pretty-quick --staged"
 	},
+	"browserslist": [
+		"last 2 versions",
+		"not ie < 11",
+		"android >= 5",
+		"ios >= 10"
+	],
 	"dependencies": {
 		"@babel/core": "^7.4.5",
 		"@babel/plugin-proposal-object-rest-spread": "^7.4.4",

--- a/src/media/js/utils/Utils.js
+++ b/src/media/js/utils/Utils.js
@@ -97,6 +97,8 @@ module.exports = {
 
 	declOfNum: function(number, titles) {
 		const cases = [2, 0, 1, 1, 1, 2];
-		return titles[number % 100 > 4 && number % 100 < 20 ? 2 : cases[number % 10 < 5 ? number % 10 : 5]];
+		return titles[
+			number % 100 > 4 && number % 100 < 20 ? 2 : cases[number % 10 < 5 ? number % 10 : 5]
+		];
 	},
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,6 +2863,18 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+escodegen@^1.8.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
+  integrity sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 escodegen@~0.0.24:
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-0.0.28.tgz#0e4ff1715f328775d6cab51ac44a406cd7abffd3"
@@ -2983,6 +2995,11 @@ esprima@^1.0.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.5.tgz#0993502feaf668138325756f30f9a51feeec11e9"
 
+esprima@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -3007,7 +3024,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -6255,7 +6272,7 @@ opn@5.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -7845,6 +7862,13 @@ stack-trace@^0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
 
+static-eval@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  dependencies:
+    escodegen "^1.8.1"
+
 static-eval@~0.2.0:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-0.2.4.tgz#b7d34d838937b969f9641ca07d48f8ede263ea7b"
@@ -8079,9 +8103,11 @@ svg-sprite@^1.3.5:
     lodash "^4.17.11"
     lodash.pluck "^3.1.2"
     mkdirp "^0.5.1"
+    mocha "^5.2.0"
     mustache "^3.0.0"
     phantomjs-prebuilt "^2.1.16"
     prettysize "^1.1.0"
+    should "^13.2.3"
     svgo "^1.1.1"
     vinyl "^2.2.0"
     winston "^3.1.0"


### PR DESCRIPTION
Added browserlist option for package.json -- instead of browsers for autoprefixer.
Removed lint warning for Utils.js.